### PR TITLE
Avoid compressing compressed files

### DIFF
--- a/ghr-compress
+++ b/ghr-compress
@@ -30,12 +30,15 @@ ghr-compress-one-zip() {
 
 ghr-compress-one() {
     local file="$1"
-    if [ "$GHR_COMPRESS" = "zip" ]; then
-        ghr-compress-one-zip "$file" >&2
-    else
-        ghr-compress-one-tar "$file"
+    local file_extension=".${file#*.}"  # get extension from the file
+    if [ "$file_extension" != "$extension" ]; then # only compress if the extensions dont match to avoid recompressing
+      if [ "$GHR_COMPRESS" = "zip" ]; then
+          ghr-compress-one-zip "$file" >&2
+      else
+          ghr-compress-one-tar "$file"
+      fi
+      rm -r -- "$file"
     fi
-    rm -r -- "$file"
 }
 
 if [ "$GHR_PATH" = "." ]; then


### PR DESCRIPTION
Simple sanity check to see if the file we are trying to compress is
already compressed with the same type as the requested, in which case we
can just skip the compression to avoid ugly names and double
compressions

Signed-off-by: Itxaka <igarcia@suse.com>