### PR TITLE
Support more options for ghr

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ The action will trigger on pushes to tags and exit neutrally otherwise.
   Can be either `gz`, `bz2`, `xz`, or `zip`.
   The correct file extension will be appended (e.g. `.tar.gz`, or `.zip`).
 
+- `GHR_DELETE` — **Optional.**
+  Delete release and its git tag in advance if it exists.
+  Can be either `true` or `false`
+
+- `GHR_REPLACE` — **Optional.**
+  Replace artifacts if it is already uploaded.
+  Can be either `true` or `false`
+
 ## Usage example
 
 ### YAML

--- a/ghr-wrapper
+++ b/ghr-wrapper
@@ -1,7 +1,15 @@
 #!/bin/bash
 set -e -u -o pipefail
+GHR_DELETE_OPT=""
+GHR_REPLACE_OPT=""
 [[ "$GITHUB_REF" != refs/tags/* ]] && echo "${GITHUB_REF} is not a tag, exiting..." && exit 78
 [ -f "$GHR_PATH" ] && cd -- "$(dirname -- "$GHR_PATH")" && export GHR_PATH="$(basename -- "$GHR_PATH")"
 [ -d "$GHR_PATH" ] && cd -- "$GHR_PATH" && export GHR_PATH=.
 [ -n "${GHR_COMPRESS:-}" ] && eval "$(/usr/local/bin/ghr-compress)"
-/usr/local/bin/ghr -u "${GITHUB_REPOSITORY%/*}" -r "${GITHUB_REPOSITORY#*/}" "${GITHUB_REF#refs/tags/}" "$GHR_PATH"
+if [ "${GHR_DELETE:-}" == "true" ]; then
+  GHR_DELETE_OPT="-delete"
+fi
+if [ "${GHR_REPLACE:-}" == "true" ]; then
+  GHR_REPLACE_OPT="-replace"
+fi
+/usr/local/bin/ghr -u "${GITHUB_REPOSITORY%/*}" -r "${GITHUB_REPOSITORY#*/}" ${GHR_DELETE_OPT} ${GHR_REPLACE_OPT} "${GITHUB_REF#refs/tags/}" "$GHR_PATH"


### PR DESCRIPTION
Adds support for both -replace and -delete arguments to ghr.

-replace will make sure to replace any uploaded artifacts in the
release, very useful to replace broken files in a given release.

-delete will make sure to delete the whole release and recreate it from
scratch if it exists, useful for recreating fully broken releases or
release mistakes

Should not affect any existing workflows using the action as all values
are optional and have default values

Signed-off-by: Itxaka <igarcia@suse.com>