### PR TITLE
Add GHR_PARALLELISM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ LABEL "com.github.actions.color"="black"
 ENV GHR_FORK tcnksm/ghr
 ENV GHR_VERSION 0.13.0
 
-RUN apk add --no-cache bash curl xz zip
+RUN apk add --no-cache bash curl xz zip coreutils
 
 RUN sh -c "curl --silent -L https://github.com/${GHR_FORK}/releases/download/v${GHR_VERSION}/ghr_v${GHR_VERSION}_linux_amd64.tar.gz > ghr_v${GHR_VERSION}_linux_amd64.tar.gz" && \
     sh -c "tar xvzf ghr_v${GHR_VERSION}_linux_amd64.tar.gz" && \

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ The action will trigger on pushes to tags and exit neutrally otherwise.
   Replace artifacts if it is already uploaded.
   Can be either `true` or `false`
 
+- `GHR_PARALLELISM` — **Optional.**
+  Set amount of parallelism
+
 ## Usage example
 
 ### YAML

--- a/ghr-wrapper
+++ b/ghr-wrapper
@@ -12,4 +12,5 @@ fi
 if [ "${GHR_REPLACE:-}" == "true" ]; then
   GHR_REPLACE_OPT="-replace"
 fi
-/usr/local/bin/ghr -u "${GITHUB_REPOSITORY%/*}" -r "${GITHUB_REPOSITORY#*/}" ${GHR_DELETE_OPT} ${GHR_REPLACE_OPT} "${GITHUB_REF#refs/tags/}" "$GHR_PATH"
+GHR_PARALLELISM=${GHR_PARALLELISM:-$(nproc)}
+/usr/local/bin/ghr -u "${GITHUB_REPOSITORY%/*}" -r "${GITHUB_REPOSITORY#*/}" -p ${GHR_PARALLELISM} ${GHR_DELETE_OPT} ${GHR_REPLACE_OPT} "${GITHUB_REF#refs/tags/}" "$GHR_PATH"


### PR DESCRIPTION
Hi!

This PR adds `GHR_PARALLELISM`. When the release contains multiple files, timeout could happen if we default to the number of procs, so this change allows to tweak the -p parameter of ghr.

